### PR TITLE
Changes default arguments for rsync to be in line with lagoon drush docs

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -26,8 +26,6 @@ var verboseSSH bool
 var RsyncArguments string
 var rsyncCopyOnly bool
 
-const copyOnlyRsyncArguments = "rlOD"
-
 var syncCmd = &cobra.Command{
 	Use:   "sync [mariadb|files|mongodb|postgres|etc.]",
 	Short: "Sync a resource type",
@@ -101,14 +99,11 @@ var syncCmd = &cobra.Command{
 		}
 
 		// SSH config
-		effectiveRsyncArguments := RsyncArguments
-		if rsyncCopyOnly {
-			effectiveRsyncArguments = copyOnlyRsyncArguments
-		}
+
 		var sshOptions = synchers.SSHOptions{
 			Verbose:    verboseSSH,
 			PrivateKey: CmdSSHKey,
-			RsyncArgs: effectiveRsyncArguments,
+			RsyncArgs: RsyncArguments,
 		}
 
 		err = synchers.RunSyncProcess(sourceEnvironment, targetEnvironment, lagoonSyncer, SyncerType, dryRun, sshOptions)
@@ -154,7 +149,6 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&noCliInteraction, "no-interaction", false, "Disallow interaction")
 	syncCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Don't run the commands, just preview what will be run")
 	syncCmd.PersistentFlags().BoolVar(&verboseSSH, "verbose", false, "Run ssh commands in verbose (useful for debugging)")
-	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "a", "Pass through arguments to change the behaviour of rsync")
-	syncCmd.PersistentFlags().BoolVar(&rsyncCopyOnly, "rsync-copy-only", false, "Only copy files, don't set any attributes, permissions, etc. overrides any rsync-args to be 'rlOD'")
+	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX", "Pass through arguments to change the behaviour of rsync")
 
 }

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -183,7 +183,7 @@ func SyncRunTransfer(sourceEnvironment Environment, targetEnvironment Environmen
 	}
 
 	rsyncArgs := sshOptions.RsyncArgs
-	execString := fmt.Sprintf("%s -%s --rsync-path=%s %s -e \"ssh%s -o LogLevel=FATAL -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 32222 -l %s ssh.lagoon.amazeeio.cloud service=%s\" %s %s %s",
+	execString := fmt.Sprintf("%s %s --rsync-path=%s %s -e \"ssh%s -o LogLevel=FATAL -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 32222 -l %s ssh.lagoon.amazeeio.cloud service=%s\" %s %s %s",
 		targetEnvironment.RsyncPath,
 		rsyncArgs,
 		sourceEnvironment.RsyncPath,


### PR DESCRIPTION
This PR brings the default behaviour of the rsync command in line with https://docs.lagoon.sh/drupal/drush-9/#update-site-aliases