### PR TITLE
Fix local hostname config in example .lagoon.yml

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -18,7 +18,7 @@ lagoon-sync:
         - "cache_menu"
     local:
       config:
-        hostname: "drupal"
+        hostname: "mariadb"
         username: "drupal"
         password: "drupal"
         port: "3306"
@@ -37,7 +37,7 @@ lagoon-sync:
         - "cache_menu"
     local:
       config:
-        hostname: "drupal"
+        hostname: "postgres"
         username: "drupal"
         password: "drupal"
         port: "3306"


### PR DESCRIPTION
If a user (or me) uses the example `.lagoon.yml` to base the sync config, they would have problems because the local db configs having the incorrect hostname.

This PR fixes the hostname to match what would be used in a pygmy style local development and also matches `lagoon-sync/.example-lagoon-sync`.

Related to #56 