### PR TITLE
Adds rsync args to ssh options

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -134,6 +134,7 @@ var syncCmd = &cobra.Command{
 			PrivateKey: sshKey,
 			Port:       sshPort,
 			Verbose:    sshVerbose,
+			RsyncArgs:  RsyncArguments,
 		}
 
 		utils.LogDebugInfo("Config that is used for SSH", sshOptions)


### PR DESCRIPTION
This fixes an issue introduced in the new release that breaks rsync options