### PR TITLE
Feature dump and download only

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -30,9 +30,9 @@ var dryRun bool
 var verboseSSH bool
 var RsyncArguments string
 var runSyncProcess synchers.RunSyncProcessFunctionType
-var noRemoteCleanup bool
-var noLocalCleanup bool
-var noImport bool
+var skipSourceCleanup bool
+var skipTargetCleanup bool
+var skipTargetImport bool
 var localTransferResourceName string
 
 var syncCmd = &cobra.Command{
@@ -154,6 +154,9 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 		SyncerType:        SyncerType,
 		DryRun:            dryRun,
 		SshOptions:        sshOptions,
+		SkipTargetCleanup: skipTargetCleanup,
+		SkipSourceCleanup: skipSourceCleanup,
+		SkipTargetImport:  skipTargetImport,
 	})
 
 	if err != nil {
@@ -199,10 +202,9 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&noCliInteraction, "no-interaction", false, "Disallow interaction")
 	syncCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Don't run the commands, just preview what will be run")
 	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX --recursive --compress", "Pass through arguments to change the behaviour of rsync")
-	syncCmd.PersistentFlags().BoolVar(&noRemoteCleanup, "no-remote-cleanup", false, "Don't clean up any of the files generated on the source")
-	syncCmd.PersistentFlags().BoolVar(&noLocalCleanup, "no-local-cleanup", false, "Don't clean up any of the files generated locally")
-	syncCmd.PersistentFlags().BoolVar(&noImport, "no-local-import", false, "This will skip the import step on the target, in combination with 'no-local-cleanup' this essentially produces a resource dump")
-	//syncCmd.PersistentFlags().StringVar(&localTransferResourceName, "local-transfer-resource-name", "", "If set, the default generated local transfer resource (typically a random file in /tmp) will be ignored and the parameter used")
+	syncCmd.PersistentFlags().BoolVar(&skipSourceCleanup, "skip-source-cleanup", false, "Don't clean up any of the files generated on the source")
+	syncCmd.PersistentFlags().BoolVar(&skipTargetCleanup, "skip-target-cleanup", false, "Don't clean up any of the files generated on the target")
+	syncCmd.PersistentFlags().BoolVar(&skipTargetImport, "skip-target-import", false, "This will skip the import step on the target, in combination with 'no-target-cleanup' this essentially produces a resource dump")
 
 	// By default, we hook up the syncers.RunSyncProcess function to the runSyncProcess variable
 	// by doing this, it lets us easily override it for testing the command - but for most of the time

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -30,6 +30,10 @@ var dryRun bool
 var verboseSSH bool
 var RsyncArguments string
 var runSyncProcess synchers.RunSyncProcessFunctionType
+var noRemoteCleanup bool
+var noLocalCleanup bool
+var noImport bool
+var localTransferResourceName string
 
 var syncCmd = &cobra.Command{
 	Use:   "sync [mariadb|files|mongodb|postgres|etc.]",
@@ -87,6 +91,10 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 	}
 
 	var lagoonSyncer synchers.Syncer
+	// Syncers are registered in their init() functions - so here we attempt to match
+	// the syncer type with the argument passed through to this command
+	// (e.g. if we're running `lagoon-sync sync mariadb --...options follow` the function
+	// GetSyncersForTypeFromConfigRoot will return a prepared mariadb syncher object)
 	lagoonSyncer, err = synchers.GetSyncerForTypeFromConfigRoot(SyncerType, configRoot)
 	if err != nil {
 		utils.LogFatalError(err.Error(), nil)
@@ -139,7 +147,15 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 
 	utils.LogDebugInfo("Config that is used for SSH", sshOptions)
 
-	err = runSyncProcess(sourceEnvironment, targetEnvironment, lagoonSyncer, SyncerType, dryRun, sshOptions)
+	err = runSyncProcess(synchers.RunSyncProcessFunctionTypeArguments{
+		SourceEnvironment: sourceEnvironment,
+		TargetEnvironment: targetEnvironment,
+		LagoonSyncer:      lagoonSyncer,
+		SyncerType:        SyncerType,
+		DryRun:            dryRun,
+		SshOptions:        sshOptions,
+	})
+
 	if err != nil {
 		utils.LogFatalError("There was an error running the sync process", err)
 	}
@@ -183,6 +199,10 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&noCliInteraction, "no-interaction", false, "Disallow interaction")
 	syncCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Don't run the commands, just preview what will be run")
 	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX --recursive --compress", "Pass through arguments to change the behaviour of rsync")
+	syncCmd.PersistentFlags().BoolVar(&noRemoteCleanup, "no-remote-cleanup", false, "Don't clean up any of the files generated on the source")
+	syncCmd.PersistentFlags().BoolVar(&noLocalCleanup, "no-local-cleanup", false, "Don't clean up any of the files generated locally")
+	syncCmd.PersistentFlags().BoolVar(&noImport, "no-local-import", false, "This will skip the import step on the target, in combination with 'no-local-cleanup' this essentially produces a resource dump")
+	//syncCmd.PersistentFlags().StringVar(&localTransferResourceName, "local-transfer-resource-name", "", "If set, the default generated local transfer resource (typically a random file in /tmp) will be ignored and the parameter used")
 
 	// By default, we hook up the syncers.RunSyncProcess function to the runSyncProcess variable
 	// by doing this, it lets us easily override it for testing the command - but for most of the time

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -29,13 +29,13 @@ func Test_syncCommandRun(t *testing.T) {
 					"mariadb",
 				},
 			},
-			runSyncProcess: func(sourceEnvironment synchers.Environment, targetEnvironment synchers.Environment, lagoonSyncer synchers.Syncer, syncerType string, dryRun bool, sshOptions synchers.SSHOptions) error {
-				if sshOptions.Port != "32222" {
-					return errors.New(fmt.Sprintf("Expecting ssh port 32222 - found: %v", sshOptions.Port))
+			runSyncProcess: func(args synchers.RunSyncProcessFunctionTypeArguments) error {
+				if args.SshOptions.Port != "32222" {
+					return errors.New(fmt.Sprintf("Expecting ssh port 32222 - found: %v", args.SshOptions.Port))
 				}
 
-				if sshOptions.Host != "ssh.lagoon.amazeeio.cloud" {
-					return errors.New(fmt.Sprintf("Expecting ssh host ssh.lagoon.amazeeio.cloud - found: %v", sshOptions.Host))
+				if args.SshOptions.Host != "ssh.lagoon.amazeeio.cloud" {
+					return errors.New(fmt.Sprintf("Expecting ssh host ssh.lagoon.amazeeio.cloud - found: %v", args.SshOptions.Host))
 				}
 
 				return nil
@@ -51,13 +51,13 @@ func Test_syncCommandRun(t *testing.T) {
 					"mariadb",
 				},
 			},
-			runSyncProcess: func(sourceEnvironment synchers.Environment, targetEnvironment synchers.Environment, lagoonSyncer synchers.Syncer, syncerType string, dryRun bool, sshOptions synchers.SSHOptions) error {
-				if sshOptions.Port != "777" {
-					return errors.New(fmt.Sprintf("Expecting ssh port 777 - found: %v", sshOptions.Port))
+			runSyncProcess: func(args synchers.RunSyncProcessFunctionTypeArguments) error {
+				if args.SshOptions.Port != "777" {
+					return errors.New(fmt.Sprintf("Expecting ssh port 777 - found: %v", args.SshOptions.Port))
 				}
 
-				if sshOptions.Host != "example.ssh.lagoon.amazeeio.cloud" {
-					return errors.New(fmt.Sprintf("Expecting ssh host ssh.lagoon.amazeeio.cloud - found: %v", sshOptions.Host))
+				if args.SshOptions.Host != "example.ssh.lagoon.amazeeio.cloud" {
+					return errors.New(fmt.Sprintf("Expecting ssh host ssh.lagoon.amazeeio.cloud - found: %v", args.SshOptions.Host))
 				}
 
 				return nil

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -27,55 +27,65 @@ func UnmarshallLagoonYamlToLagoonSyncStructure(data []byte) (SyncherConfigRoot, 
 	return lagoonConfig, nil
 }
 
-type RunSyncProcessFunctionType = func(sourceEnvironment Environment, targetEnvironment Environment, lagoonSyncer Syncer, syncerType string, dryRun bool, sshOptions SSHOptions) error
+type RunSyncProcessFunctionTypeArguments struct {
+	SourceEnvironment Environment
+	TargetEnvironment Environment
+	LagoonSyncer      Syncer
+	SyncerType        string
+	DryRun            bool
+	SshOptions        SSHOptions
+}
 
-func RunSyncProcess(sourceEnvironment Environment, targetEnvironment Environment, lagoonSyncer Syncer, syncerType string, dryRun bool, sshOptions SSHOptions) error {
+type RunSyncProcessFunctionType = func(args RunSyncProcessFunctionTypeArguments) error
+
+func RunSyncProcess(args RunSyncProcessFunctionTypeArguments) error {
 	var err error
 
-	if _, err := lagoonSyncer.IsInitialized(); err != nil {
+	if _, err := args.LagoonSyncer.IsInitialized(); err != nil {
 		return err
 	}
 
-	sourceEnvironment, err = RunPrerequisiteCommand(sourceEnvironment, lagoonSyncer, syncerType, dryRun, sshOptions)
-	sourceRsyncPath := sourceEnvironment.RsyncPath
+	//TODO: this can come out.
+	args.SourceEnvironment, err = RunPrerequisiteCommand(args.SourceEnvironment, args.LagoonSyncer, args.SyncerType, args.DryRun, args.SshOptions)
+	sourceRsyncPath := args.SourceEnvironment.RsyncPath
 	if err != nil {
-		_ = PrerequisiteCleanUp(sourceEnvironment, sourceRsyncPath, dryRun, sshOptions)
+		_ = PrerequisiteCleanUp(args.SourceEnvironment, sourceRsyncPath, args.DryRun, args.SshOptions)
 		return err
 	}
 
-	err = SyncRunSourceCommand(sourceEnvironment, lagoonSyncer, dryRun, sshOptions)
+	err = SyncRunSourceCommand(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 	if err != nil {
-		_ = SyncCleanUp(sourceEnvironment, lagoonSyncer, dryRun, sshOptions)
+		_ = SyncCleanUp(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 		return err
 	}
 
-	targetEnvironment, err = RunPrerequisiteCommand(targetEnvironment, lagoonSyncer, syncerType, dryRun, sshOptions)
-	targetRsyncPath := targetEnvironment.RsyncPath
+	args.TargetEnvironment, err = RunPrerequisiteCommand(args.TargetEnvironment, args.LagoonSyncer, args.SyncerType, args.DryRun, args.SshOptions)
+	targetRsyncPath := args.TargetEnvironment.RsyncPath
 	if err != nil {
-		_ = PrerequisiteCleanUp(targetEnvironment, targetRsyncPath, dryRun, sshOptions)
+		_ = PrerequisiteCleanUp(args.TargetEnvironment, targetRsyncPath, args.DryRun, args.SshOptions)
 		return err
 	}
 
-	err = SyncRunTransfer(sourceEnvironment, targetEnvironment, lagoonSyncer, dryRun, sshOptions)
+	err = SyncRunTransfer(args.SourceEnvironment, args.TargetEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 	if err != nil {
-		_ = PrerequisiteCleanUp(sourceEnvironment, sourceRsyncPath, dryRun, sshOptions)
-		_ = SyncCleanUp(sourceEnvironment, lagoonSyncer, dryRun, sshOptions)
+		_ = PrerequisiteCleanUp(args.SourceEnvironment, sourceRsyncPath, args.DryRun, args.SshOptions)
+		_ = SyncCleanUp(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 		return err
 	}
 
-	err = SyncRunTargetCommand(targetEnvironment, lagoonSyncer, dryRun, sshOptions)
+	err = SyncRunTargetCommand(args.TargetEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 	if err != nil {
-		_ = PrerequisiteCleanUp(sourceEnvironment, sourceRsyncPath, dryRun, sshOptions)
-		_ = PrerequisiteCleanUp(targetEnvironment, targetRsyncPath, dryRun, sshOptions)
-		_ = SyncCleanUp(sourceEnvironment, lagoonSyncer, dryRun, sshOptions)
-		_ = SyncCleanUp(targetEnvironment, lagoonSyncer, dryRun, sshOptions)
+		_ = PrerequisiteCleanUp(args.SourceEnvironment, sourceRsyncPath, args.DryRun, args.SshOptions)
+		_ = PrerequisiteCleanUp(args.TargetEnvironment, targetRsyncPath, args.DryRun, args.SshOptions)
+		_ = SyncCleanUp(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
+		_ = SyncCleanUp(args.TargetEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 		return err
 	}
 
-	_ = PrerequisiteCleanUp(sourceEnvironment, sourceRsyncPath, dryRun, sshOptions)
-	_ = PrerequisiteCleanUp(targetEnvironment, targetRsyncPath, dryRun, sshOptions)
-	_ = SyncCleanUp(sourceEnvironment, lagoonSyncer, dryRun, sshOptions)
-	_ = SyncCleanUp(targetEnvironment, lagoonSyncer, dryRun, sshOptions)
+	_ = PrerequisiteCleanUp(args.SourceEnvironment, sourceRsyncPath, args.DryRun, args.SshOptions)
+	_ = PrerequisiteCleanUp(args.TargetEnvironment, targetRsyncPath, args.DryRun, args.SshOptions)
+	_ = SyncCleanUp(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
+	_ = SyncCleanUp(args.TargetEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
 
 	return nil
 }


### PR DESCRIPTION
This PR introduces the ability to, potentially, just do a dump of a resource in some external environment and pull it down locally to a file, rather than always importing and deleting the temporary files.
Specifically, it introduces the params `--skip-target-cleanup=true` and `--skip-target-import=true` that when set will dump a DB locally.

```
./lagoon-sync sync mariadb -p source-project-name -e source-environment --skip-target-cleanup=true --skip-target-import=true`
<SNIP>
2022/08/26 00:38:46 Running the following: 
ssh -tt -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -p 32222 source-project-name-source-environment@ssh.lagoon service=cli 'rm -r /tmp/lagoon_sync_mariadb_1661474271866007904.sql.gz || true'
File on the target saved as: /tmp/lagoon_sync_mariadb_1661474271866007904.sql.gz
2022/08/26 00:38:58 
```