### PR TITLE
Remove output color control chars

### DIFF
--- a/utils/logs.go
+++ b/utils/logs.go
@@ -11,31 +11,31 @@ import (
 
 func LogProcessStep(message string, output interface{}) {
 	if output == nil {
-		fmt.Printf("\x1b[32;1m%s\x1b[0m\n", message)
+		fmt.Printf("%s\n", message)
 	} else if output != nil {
-		fmt.Printf("\x1b[32;1m%s\x1b[0m: %s\n", message, output)
+		fmt.Printf("%s: %s\n", message, output)
 	}
 }
 
 func LogExecutionStep(message string, output interface{}) {
 	if output == nil {
-		log.Printf("\x1b[36;1m%s\x1b[0m", message)
+		log.Printf("%s\n", message)
 	} else if output != nil {
-		log.Printf("\x1b[36;1m%s\x1b[0m: \n\x1b[30;1m%s\x1b[0m", message, output)
+		log.Printf("%s: %s\n", message, output)
 	}
 }
 
 func LogDebugInfo(message string, output interface{}) {
 	if debug := viper.Get("show-debug"); debug == true {
 		if output == nil {
-			log.Printf("\x1b[37;1m(DEBUG)\x1b[0m %s", message)
+			log.Printf("(DEBUG) %s\n", message)
 		} else if output != nil {
 			if reflect.TypeOf(output).String() == "string" {
-				log.Printf("\x1b[37;1m(DEBUG)\x1b[0m %s: %s", message, output)
+				log.Printf("(DEBUG) %s: %s\n", message, output)
 			}
 			if reflect.TypeOf(output).String() != "string" {
 				s, _ := json.MarshalIndent(output, "", "  ")
-				log.Printf("\x1b[37;1m(DEBUG)\x1b[0m %s:\n %s", message, string(s))
+				log.Printf("(DEBUG) %s:\n %s\n", message, string(s))
 			}
 		}
 	}
@@ -43,16 +43,16 @@ func LogDebugInfo(message string, output interface{}) {
 
 func LogFatalError(message string, output interface{}) {
 	if output == nil {
-		log.Fatalf("\x1b[31m(ERROR)\x1b[0m - %s", message)
+		log.Fatalf("(ERROR) - %s\n", message)
 	} else if output != nil {
-		log.Fatalf("\x1b[31m(ERROR)\x1b[0m - %s: %s", message, output)
+		log.Fatalf("(ERROR) - %s: %s\n", message, output)
 	}
 }
 
 func LogWarning(message string, output interface{}) {
 	if output == nil {
-		log.Printf("\n-----\n\x1b[33;1mWarning:\x1b[0m %s\n-----", message)
+		log.Printf("\n-----\nWarning: %s\n-----", message)
 	} else if output != nil {
-		log.Printf("\n-----\n\x1b[33;1mWarning:\x1b[0m %s: %v\n-----", message, output)
+		log.Printf("\n-----\nWarning: %s: %v\n-----", message, output)
 	}
 }

--- a/utils/logs.go
+++ b/utils/logs.go
@@ -51,8 +51,8 @@ func LogFatalError(message string, output interface{}) {
 
 func LogWarning(message string, output interface{}) {
 	if output == nil {
-		log.Printf("\n-----\nWarning: %s\n-----", message)
+		log.Printf("\n-----\nWarning: %s\n-----\n", message)
 	} else if output != nil {
-		log.Printf("\n-----\nWarning: %s: %v\n-----", message, output)
+		log.Printf("\n-----\nWarning: %s: %v\n-----\n", message, output)
 	}
 }


### PR DESCRIPTION
This PR addresses #68 - it removes the colour special chars in the logs - this makes it easier to read, as well as not injecting spurious data into the logs