### PR TITLE
Support multiple commands in synchers.

### DIFF
--- a/synchers/drupalconfig.go
+++ b/synchers/drupalconfig.go
@@ -91,6 +91,13 @@ func (m DrupalconfigSyncRoot) GetLocalCommand(environment Environment) []SyncCom
 
 }
 
+func (m DrupalconfigSyncRoot) GetFilesToCleanup(environment Environment) []string {
+	transferResource := m.GetTransferResource(environment)
+	return []string{
+		transferResource.Name,
+	}
+}
+
 func (m DrupalconfigSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
 	return SyncerTransferResource{
 		Name:        fmt.Sprintf("%vdrupalconfig-sync-%v", m.GetOutputDirectory(), m.TransferId),

--- a/synchers/drupalconfig.go
+++ b/synchers/drupalconfig.go
@@ -70,19 +70,23 @@ func (root DrupalconfigSyncRoot) GetPrerequisiteCommand(environment Environment,
 	return SyncCommand{}
 }
 
-func (root DrupalconfigSyncRoot) GetRemoteCommand(environment Environment) SyncCommand {
+func (root DrupalconfigSyncRoot) GetRemoteCommand(environment Environment) []SyncCommand {
 	transferResource := root.GetTransferResource(environment)
-	return SyncCommand{
-		command: fmt.Sprintf("drush config-export --destination=%s || true", transferResource.Name),
+	return []SyncCommand{
+		{
+			command: fmt.Sprintf("drush config-export --destination=%s || true", transferResource.Name),
+		},
 	}
 }
 
-func (m DrupalconfigSyncRoot) GetLocalCommand(environment Environment) SyncCommand {
+func (m DrupalconfigSyncRoot) GetLocalCommand(environment Environment) []SyncCommand {
 	// l := m.getEffectiveLocalDetails()
 	transferResource := m.GetTransferResource(environment)
 
-	return SyncCommand{
-		command: fmt.Sprintf("drush -y config-import --source=%s || true", transferResource.Name),
+	return []SyncCommand{
+		{
+			command: fmt.Sprintf("drush -y config-import --source=%s || true", transferResource.Name),
+		},
 	}
 
 }

--- a/synchers/files.go
+++ b/synchers/files.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/uselagoon/lagoon-sync/utils"
 	"github.com/spf13/viper"
+	"github.com/uselagoon/lagoon-sync/utils"
 )
 
 type BaseFilesSync struct {
@@ -90,12 +90,16 @@ func (root FilesSyncRoot) GetPrerequisiteCommand(environment Environment, comman
 	return SyncCommand{}
 }
 
-func (root FilesSyncRoot) GetRemoteCommand(environment Environment) SyncCommand {
-	return generateNoOpSyncCommand()
+func (root FilesSyncRoot) GetRemoteCommand(environment Environment) []SyncCommand {
+	return []SyncCommand{
+		generateNoOpSyncCommand(),
+	}
 }
 
-func (m FilesSyncRoot) GetLocalCommand(environment Environment) SyncCommand {
-	return generateNoOpSyncCommand()
+func (m FilesSyncRoot) GetLocalCommand(environment Environment) []SyncCommand {
+	return []SyncCommand{
+		generateNoOpSyncCommand(),
+	}
 }
 
 func (m FilesSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {

--- a/synchers/files.go
+++ b/synchers/files.go
@@ -102,6 +102,13 @@ func (m FilesSyncRoot) GetLocalCommand(environment Environment) []SyncCommand {
 	}
 }
 
+func (m FilesSyncRoot) GetFilesToCleanup(environment Environment) []string {
+	transferResource := m.GetTransferResource(environment)
+	return []string{
+		transferResource.Name,
+	}
+}
+
 func (m FilesSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
 	config := m.Config
 	if environment.EnvironmentName == LOCAL_ENVIRONMENT_NAME {

--- a/synchers/mariadb.go
+++ b/synchers/mariadb.go
@@ -195,6 +195,15 @@ func (m MariadbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCo
 	}
 }
 
+func (m MariadbSyncRoot) GetFilesToCleanup(environment Environment) []string {
+	transferResource := m.GetTransferResource(environment)
+	resourceNameWithoutGz := strings.TrimSuffix(transferResource.Name, filepath.Ext(transferResource.Name))
+	return []string{
+		transferResource.Name,
+		resourceNameWithoutGz,
+	}
+}
+
 func (m MariadbSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
 	return SyncerTransferResource{
 		Name:        fmt.Sprintf("%vlagoon_sync_mariadb_%v.sql.gz", m.GetOutputDirectory(), m.TransferId),

--- a/synchers/mongodb.go
+++ b/synchers/mongodb.go
@@ -153,6 +153,13 @@ func (m MongoDbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCo
 	}
 }
 
+func (m MongoDbSyncRoot) GetFilesToCleanup(environment Environment) []string {
+	transferResource := m.GetTransferResource(environment)
+	return []string{
+		transferResource.Name,
+	}
+}
+
 func (m MongoDbSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
 	return SyncerTransferResource{
 		Name:        fmt.Sprintf("%vlagoon_sync_mongodb_%v.bson", m.GetOutputDirectory(), m.TransferId),

--- a/synchers/mongodb.go
+++ b/synchers/mongodb.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/uselagoon/lagoon-sync/utils"
 	"github.com/spf13/viper"
+	"github.com/uselagoon/lagoon-sync/utils"
 )
 
 type BaseMongoDbSync struct {
@@ -116,7 +116,7 @@ func (root MongoDbSyncRoot) GetPrerequisiteCommand(environment Environment, comm
 	}
 }
 
-func (root MongoDbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) SyncCommand {
+func (root MongoDbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) []SyncCommand {
 	m := root.Config
 
 	if sourceEnvironment.EnvironmentName == LOCAL_ENVIRONMENT_NAME {
@@ -124,7 +124,7 @@ func (root MongoDbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) Sync
 	}
 
 	transferResource := root.GetTransferResource(sourceEnvironment)
-	return SyncCommand{
+	return []SyncCommand{{
 		command: fmt.Sprintf("mongodump --host {{ .hostname }} --port {{ .port }} --db {{ .database }} --archive={{ .transferResource }}"),
 		substitutions: map[string]interface{}{
 			"hostname":         m.DbHostname,
@@ -132,22 +132,25 @@ func (root MongoDbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) Sync
 			"database":         m.DbDatabase,
 			"transferResource": transferResource.Name,
 		},
+	},
 	}
 }
 
-func (m MongoDbSyncRoot) GetLocalCommand(targetEnvironment Environment) SyncCommand {
+func (m MongoDbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCommand {
 	l := m.Config
 	if targetEnvironment.EnvironmentName == LOCAL_ENVIRONMENT_NAME {
 		l = m.getEffectiveLocalDetails()
 	}
 	transferResource := m.GetTransferResource(targetEnvironment)
-	return generateSyncCommand("mongorestore --drop --host {{ .hostname }} --port {{ .port }} --archive={{ .transferResource }}",
-		map[string]interface{}{
-			"hostname":         l.DbHostname,
-			"port":             l.DbPort,
-			"database":         l.DbDatabase,
-			"transferResource": transferResource.Name,
-		})
+	return []SyncCommand{
+		generateSyncCommand("mongorestore --drop --host {{ .hostname }} --port {{ .port }} --archive={{ .transferResource }}",
+			map[string]interface{}{
+				"hostname":         l.DbHostname,
+				"port":             l.DbPort,
+				"database":         l.DbDatabase,
+				"transferResource": transferResource.Name,
+			}),
+	}
 }
 
 func (m MongoDbSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {

--- a/synchers/postgres.go
+++ b/synchers/postgres.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/uselagoon/lagoon-sync/utils"
 	"github.com/spf13/viper"
+	"github.com/uselagoon/lagoon-sync/utils"
 )
 
 type BasePostgresSync struct {
@@ -117,7 +117,7 @@ func (root PostgresSyncRoot) GetPrerequisiteCommand(environment Environment, com
 	}
 }
 
-func (root PostgresSyncRoot) GetRemoteCommand(environment Environment) SyncCommand {
+func (root PostgresSyncRoot) GetRemoteCommand(environment Environment) []SyncCommand {
 	m := root.Config
 	transferResource := root.GetTransferResource(environment)
 
@@ -131,16 +131,19 @@ func (root PostgresSyncRoot) GetRemoteCommand(environment Environment) SyncComma
 		tablesWhoseDataToExclude += fmt.Sprintf("--exclude-table-data=%s.%s ", m.DbDatabase, s)
 	}
 
-	return SyncCommand{
-		command: fmt.Sprintf("PGPASSWORD=\"%s\" pg_dump -h%s -U%s -p%s -d%s %s %s -Fc -w -f%s", m.DbPassword, m.DbHostname, m.DbUsername, m.DbPort, m.DbDatabase, tablesToExclude, tablesWhoseDataToExclude, transferResource.Name),
+	return []SyncCommand{
+		{
+			command: fmt.Sprintf("PGPASSWORD=\"%s\" pg_dump -h%s -U%s -p%s -d%s %s %s -Fc -w -f%s", m.DbPassword, m.DbHostname, m.DbUsername, m.DbPort, m.DbDatabase, tablesToExclude, tablesWhoseDataToExclude, transferResource.Name),
+		},
 	}
 }
 
-func (m PostgresSyncRoot) GetLocalCommand(environment Environment) SyncCommand {
+func (m PostgresSyncRoot) GetLocalCommand(environment Environment) []SyncCommand {
 	l := m.getEffectiveLocalDetails()
 	transferResource := m.GetTransferResource(environment)
-	return SyncCommand{
+	return []SyncCommand{{
 		command: fmt.Sprintf("PGPASSWORD=\"%s\" pg_restore -c -x -w -h%s -d%s -p%s -U%s %s", l.DbPassword, l.DbHostname, l.DbDatabase, l.DbPort, l.DbUsername, transferResource.Name),
+	},
 	}
 }
 

--- a/synchers/postgres.go
+++ b/synchers/postgres.go
@@ -147,6 +147,13 @@ func (m PostgresSyncRoot) GetLocalCommand(environment Environment) []SyncCommand
 	}
 }
 
+func (m PostgresSyncRoot) GetFilesToCleanup(environment Environment) []string {
+	transferResource := m.GetTransferResource(environment)
+	return []string{
+		transferResource.Name,
+	}
+}
+
 func (m PostgresSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
 	return SyncerTransferResource{
 		Name:        fmt.Sprintf("%vlagoon_sync_postgres_%v.sql", m.GetOutputDirectory(), m.TransferId),

--- a/synchers/syncdefs.go
+++ b/synchers/syncdefs.go
@@ -15,9 +15,9 @@ type Syncer interface {
 	// GetPrerequisiteCommand will return the command to run on source or target environment to extract information.
 	GetPrerequisiteCommand(environment Environment, command string) SyncCommand
 	// GetRemoteCommand will return the command to be run on the source system
-	GetRemoteCommand(environment Environment) SyncCommand
+	GetRemoteCommand(environment Environment) []SyncCommand
 	// GetLocalCommand will return the command to be run on the target system
-	GetLocalCommand(environment Environment) SyncCommand
+	GetLocalCommand(environment Environment) []SyncCommand
 	// GetTransferResource will return the command that executes the transfer
 	GetTransferResource(environment Environment) SyncerTransferResource
 	// PrepareSyncer does any preparations required on a Syncer before it is used

--- a/synchers/syncdefs.go
+++ b/synchers/syncdefs.go
@@ -20,6 +20,8 @@ type Syncer interface {
 	GetLocalCommand(environment Environment) []SyncCommand
 	// GetTransferResource will return the command that executes the transfer
 	GetTransferResource(environment Environment) SyncerTransferResource
+	// GetFilesToCleanup will return a list of files to be deleted after completing the transfer
+	GetFilesToCleanup(environment Environment) []string
 	// PrepareSyncer does any preparations required on a Syncer before it is used
 	PrepareSyncer() (Syncer, error)
 	// IsInitialized will tell client code if the syncer is ready to rumble

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -260,21 +260,25 @@ func SyncCleanUp(environment Environment, syncer Syncer, dryRun bool, sshOptions
 		log.Printf("Skipping cleanup for %v on %v environment", transferResouce.Name, environment.EnvironmentName)
 		return nil
 	}
-
-	transferResourceName := transferResouce.Name
-	execString := fmt.Sprintf("rm -r %s || true", transferResourceName)
-
-	if environment.EnvironmentName != LOCAL_ENVIRONMENT_NAME {
-		execString = GenerateRemoteCommand(environment, execString, sshOptions)
-	}
-
 	utils.LogProcessStep("Beginning resource cleanup on", environment.EnvironmentName)
-	utils.LogExecutionStep("Running the following", execString)
 
-	if !dryRun {
-		err, _, errstring := utils.Shellout(execString)
-		if err != nil {
-			utils.LogFatalError(errstring, nil)
+	filesToCleanUp := syncer.GetFilesToCleanup(environment)
+
+	for _, fileToCleanup := range filesToCleanUp {
+		transferResourceName := fileToCleanup
+		execString := fmt.Sprintf("rm -r %s || true", transferResourceName)
+
+		if environment.EnvironmentName != LOCAL_ENVIRONMENT_NAME {
+			execString = GenerateRemoteCommand(environment, execString, sshOptions)
+		}
+
+		utils.LogExecutionStep("Running the following", execString)
+
+		if !dryRun {
+			err, _, errstring := utils.Shellout(execString)
+			if err != nil {
+				utils.LogFatalError(errstring, nil)
+			}
 		}
 	}
 


### PR DESCRIPTION
The idea here is to start supporting multiple commands sent to the source and destination - this lets us work around some issues we've been having with `ash` support for certain kinds of redirections.

I've also added the possibility of passing multiple cleanup files.