### PR TITLE
Moves substitutions to better type

### DIFF
--- a/synchers/mariadb.go
+++ b/synchers/mariadb.go
@@ -115,7 +115,7 @@ func (root MariadbSyncRoot) GetPrerequisiteCommand(environment Environment, comm
 
 	return SyncCommand{
 		command: fmt.Sprintf("{{ .bin }} {{ .command }} || true"),
-		substitutions: map[string]interface{}{
+		substitutions: map[string]string{
 			"bin":     lagoonSyncBin,
 			"command": command,
 		},
@@ -144,7 +144,7 @@ func (root MariadbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) []Sy
 	//We remove the `.gz` from the transfer resource name for because we _first_ generate a plain `.sql` file
 	//and _then_ gzip it
 	resourceNameWithoutGz := strings.TrimSuffix(transferResource.Name, filepath.Ext(transferResource.Name))
-	substitutions := map[string]interface{}{
+	substitutions := map[string]string{
 		"dumpOptions":      "--max-allowed-packet=500M --quick --add-locks --no-autocommit --single-transaction",
 		"hostname":         m.DbHostname,
 		"username":         m.DbUsername,
@@ -175,7 +175,7 @@ func (m MariadbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCo
 	resourceNameWithoutGz := strings.TrimSuffix(transferResource.Name, filepath.Ext(transferResource.Name))
 	return []SyncCommand{
 		generateSyncCommand("gunzip {{ .transferResource }}",
-			map[string]interface{}{
+			map[string]string{
 				"hostname":         l.DbHostname,
 				"username":         l.DbUsername,
 				"password":         l.DbPassword,
@@ -184,7 +184,7 @@ func (m MariadbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCo
 				"transferResource": transferResource.Name,
 			}),
 		generateSyncCommand("mysql -h{{ .hostname }} -u{{ .username }} -p{{ .password }} -P{{ .port }} {{ .database }} < {{ .resourceNameWithoutGz }}",
-			map[string]interface{}{
+			map[string]string{
 				"hostname":              l.DbHostname,
 				"username":              l.DbUsername,
 				"password":              l.DbPassword,

--- a/synchers/mongodb.go
+++ b/synchers/mongodb.go
@@ -109,7 +109,7 @@ func (root MongoDbSyncRoot) GetPrerequisiteCommand(environment Environment, comm
 
 	return SyncCommand{
 		command: fmt.Sprintf("{{ .bin }} {{ .command }} || true"),
-		substitutions: map[string]interface{}{
+		substitutions: map[string]string{
 			"bin":     lagoonSyncBin,
 			"command": command,
 		},
@@ -126,7 +126,7 @@ func (root MongoDbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) []Sy
 	transferResource := root.GetTransferResource(sourceEnvironment)
 	return []SyncCommand{{
 		command: fmt.Sprintf("mongodump --host {{ .hostname }} --port {{ .port }} --db {{ .database }} --archive={{ .transferResource }}"),
-		substitutions: map[string]interface{}{
+		substitutions: map[string]string{
 			"hostname":         m.DbHostname,
 			"port":             m.DbPort,
 			"database":         m.DbDatabase,
@@ -144,7 +144,7 @@ func (m MongoDbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCo
 	transferResource := m.GetTransferResource(targetEnvironment)
 	return []SyncCommand{
 		generateSyncCommand("mongorestore --drop --host {{ .hostname }} --port {{ .port }} --archive={{ .transferResource }}",
-			map[string]interface{}{
+			map[string]string{
 				"hostname":         l.DbHostname,
 				"port":             l.DbPort,
 				"database":         l.DbDatabase,

--- a/synchers/postgres.go
+++ b/synchers/postgres.go
@@ -110,7 +110,7 @@ func (root PostgresSyncRoot) GetPrerequisiteCommand(environment Environment, com
 
 	return SyncCommand{
 		command: fmt.Sprintf("{{ .bin }} {{ .command }}"),
-		substitutions: map[string]interface{}{
+		substitutions: map[string]string{
 			"bin":     lagoonSyncBin,
 			"command": command,
 		},

--- a/synchers/syncdefs.go
+++ b/synchers/syncdefs.go
@@ -30,7 +30,7 @@ type Syncer interface {
 
 type SyncCommand struct {
 	command       string
-	substitutions map[string]interface{}
+	substitutions map[string]string
 	NoOp          bool // NoOp can be set to true if this command performs no operation (in situations like file transfers)
 }
 

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -291,7 +291,7 @@ func generateNoOpSyncCommand() SyncCommand {
 	}
 }
 
-func generateSyncCommand(commandString string, substitutions map[string]interface{}) SyncCommand {
+func generateSyncCommand(commandString string, substitutions map[string]string) SyncCommand {
 	return SyncCommand{
 		command:       commandString,
 		substitutions: substitutions,


### PR DESCRIPTION
For some reason (which I can't remember, and which makes no sense - likely too much JS) we went with the weakest map we could find to do string substitutions for commands. This remedies that.