### PR TITLE
Re-introducing colourised output with relevant flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Flags:
   -c, --configuration-file string        File containing sync configuration.
       --dry-run                          Don't run the commands, just preview what will be run
   -h, --help                             help for sync
-      --no-colour                        Output is not colourised
       --no-interaction                   Disallow interaction
   -p, --project-name string              The Lagoon project name of the remote system
   -r, --rsync-args string                Pass through arguments to change the behaviour of rsync (default "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX -r")

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Flags:
   -c, --configuration-file string        File containing sync configuration.
       --dry-run                          Don't run the commands, just preview what will be run
   -h, --help                             help for sync
+      --no-colour                        Output is not colourised
       --no-interaction                   Disallow interaction
   -p, --project-name string              The Lagoon project name of the remote system
   -r, --rsync-args string                Pass through arguments to change the behaviour of rsync (default "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX -r")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -30,7 +30,6 @@ var noCliInteraction bool
 var dryRun bool
 var verboseSSH bool
 var RsyncArguments string
-var noColour bool
 var runSyncProcess synchers.RunSyncProcessFunctionType
 
 var syncCmd = &cobra.Command{
@@ -109,10 +108,6 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if noColour {
-		utils.SetColour(false)
-	}
-
 	// SSH Config from file
 	sshConfig := synchers.SSHOptions{}
 	if configRoot.LagoonSync["ssh"] != nil {
@@ -189,7 +184,6 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&SSHVerbose, "verbose", false, "Run ssh commands in verbose (useful for debugging)")
 	syncCmd.PersistentFlags().BoolVar(&noCliInteraction, "no-interaction", false, "Disallow interaction")
 	syncCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Don't run the commands, just preview what will be run")
-	syncCmd.PersistentFlags().BoolVar(&noColour, "no-colour", false, "Output is not colourised")
 	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX --recursive --compress", "Pass through arguments to change the behaviour of rsync")
 
 	// By default, we hook up the syncers.RunSyncProcess function to the runSyncProcess variable

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -29,6 +30,7 @@ var noCliInteraction bool
 var dryRun bool
 var verboseSSH bool
 var RsyncArguments string
+var noColour bool
 var runSyncProcess synchers.RunSyncProcessFunctionType
 
 var syncCmd = &cobra.Command{
@@ -101,9 +103,14 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 			ProjectName,
 			SyncerType,
 			sourceEnvironmentName, targetEnvironmentName))
+		utils.SetColour(true)
 		if err != nil || !confirmationResult {
 			utils.LogFatalError("User cancelled sync - exiting", nil)
 		}
+	}
+
+	if noColour {
+		utils.SetColour(false)
 	}
 
 	// SSH Config from file
@@ -182,6 +189,7 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&SSHVerbose, "verbose", false, "Run ssh commands in verbose (useful for debugging)")
 	syncCmd.PersistentFlags().BoolVar(&noCliInteraction, "no-interaction", false, "Disallow interaction")
 	syncCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Don't run the commands, just preview what will be run")
+	syncCmd.PersistentFlags().BoolVar(&noColour, "no-colour", false, "Output is not colourised")
 	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX --recursive --compress", "Pass through arguments to change the behaviour of rsync")
 
 	// By default, we hook up the syncers.RunSyncProcess function to the runSyncProcess variable

--- a/utils/logs.go
+++ b/utils/logs.go
@@ -2,57 +2,93 @@ package utils
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
+	"os"
 	"reflect"
 
 	"github.com/spf13/viper"
+	"github.com/withmandala/go-log"
 )
 
+var colour bool
+
+func SetColour(c bool) {
+	colour = c
+}
+
 func LogProcessStep(message string, output interface{}) {
+	logger := log.New(os.Stdout)
+	if colour {
+		logger.WithColor()
+	} else {
+		logger.WithoutColor()
+	}
 	if output == nil {
-		fmt.Printf("%s\n", message)
+		logger.Info(message)
 	} else if output != nil {
-		fmt.Printf("%s: %s\n", message, output)
+		logger.Info(message, output)
 	}
 }
 
 func LogExecutionStep(message string, output interface{}) {
+	logger := log.New(os.Stdout)
+	if colour {
+		logger.WithColor()
+	} else {
+		logger.WithoutColor()
+	}
 	if output == nil {
-		log.Printf("%s\n", message)
+		logger.Info(message)
 	} else if output != nil {
-		log.Printf("%s: %s\n", message, output)
+		logger.Info(message, output)
 	}
 }
 
 func LogDebugInfo(message string, output interface{}) {
+	logger := log.New(os.Stdout).WithDebug()
+	if colour {
+		logger.WithColor()
+	} else {
+		logger.WithoutColor()
+	}
 	if debug := viper.Get("show-debug"); debug == true {
 		if output == nil {
-			log.Printf("(DEBUG) %s\n", message)
+			logger.Debug(message)
 		} else if output != nil {
 			if reflect.TypeOf(output).String() == "string" {
-				log.Printf("(DEBUG) %s: %s\n", message, output)
+				logger.Debug(message, output)
 			}
 			if reflect.TypeOf(output).String() != "string" {
 				s, _ := json.MarshalIndent(output, "", "  ")
-				log.Printf("(DEBUG) %s:\n %s\n", message, string(s))
+				logger.Debug(message, string(s))
 			}
 		}
 	}
 }
 
 func LogFatalError(message string, output interface{}) {
+	logger := log.New(os.Stdout)
+	if colour {
+		logger.WithColor()
+	} else {
+		logger.WithoutColor()
+	}
 	if output == nil {
-		log.Fatalf("(ERROR) - %s\n", message)
+		logger.Fatal(message)
 	} else if output != nil {
-		log.Fatalf("(ERROR) - %s: %s\n", message, output)
+		logger.Fatal(message, output)
 	}
 }
 
 func LogWarning(message string, output interface{}) {
+	logger := log.New(os.Stdout)
+	if colour {
+		logger.WithColor()
+	} else {
+		logger.WithoutColor()
+	}
 	if output == nil {
-		log.Printf("\n-----\nWarning: %s\n-----\n", message)
+		logger.Warn(message)
 	} else if output != nil {
-		log.Printf("\n-----\nWarning: %s: %v\n-----\n", message, output)
+		logger.Warn(message, output)
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/uselagoon/lagoon-sync/issues/70

Colourised output re-introduced via https://github.com/Mandala/go-log

Output is colourised when in interactive mode & disabled when either `noCliInteraction` or `noColour` is flagged.