### PR TITLE
Adds new option for specifying transfer file name

### DIFF
--- a/synchers/drupalconfig.go
+++ b/synchers/drupalconfig.go
@@ -59,7 +59,7 @@ func init() {
 
 func (root DrupalconfigSyncRoot) PrepareSyncer() (Syncer, error) {
 	root.TransferId = strconv.FormatInt(time.Now().UnixNano(), 10)
-	return root, nil
+	return &root, nil
 }
 
 func (m DrupalconfigSyncRoot) IsInitialized() (bool, error) {
@@ -102,6 +102,10 @@ func (m DrupalconfigSyncRoot) GetTransferResource(environment Environment) Synce
 	return SyncerTransferResource{
 		Name:        fmt.Sprintf("%vdrupalconfig-sync-%v", m.GetOutputDirectory(), m.TransferId),
 		IsDirectory: true}
+}
+
+func (m *DrupalconfigSyncRoot) SetTransferResource(transferResourceName string) error {
+	return fmt.Errorf("Setting the transfer resource is not supported for drupal config")
 }
 
 func (root DrupalconfigSyncRoot) GetOutputDirectory() string {

--- a/synchers/files.go
+++ b/synchers/files.go
@@ -77,39 +77,39 @@ func init() {
 	RegisterSyncer(FilesSyncPlugin{})
 }
 
-func (m FilesSyncRoot) IsInitialized() (bool, error) {
+func (m *FilesSyncRoot) IsInitialized() (bool, error) {
 	return true, nil
 }
 
-func (root FilesSyncRoot) PrepareSyncer() (Syncer, error) {
+func (root *FilesSyncRoot) PrepareSyncer() (Syncer, error) {
 	root.TransferId = strconv.FormatInt(time.Now().UnixNano(), 10)
 	return root, nil
 }
 
-func (root FilesSyncRoot) GetPrerequisiteCommand(environment Environment, command string) SyncCommand {
+func (root *FilesSyncRoot) GetPrerequisiteCommand(environment Environment, command string) SyncCommand {
 	return SyncCommand{}
 }
 
-func (root FilesSyncRoot) GetRemoteCommand(environment Environment) []SyncCommand {
+func (root *FilesSyncRoot) GetRemoteCommand(environment Environment) []SyncCommand {
 	return []SyncCommand{
 		generateNoOpSyncCommand(),
 	}
 }
 
-func (m FilesSyncRoot) GetLocalCommand(environment Environment) []SyncCommand {
+func (m *FilesSyncRoot) GetLocalCommand(environment Environment) []SyncCommand {
 	return []SyncCommand{
 		generateNoOpSyncCommand(),
 	}
 }
 
-func (m FilesSyncRoot) GetFilesToCleanup(environment Environment) []string {
+func (m *FilesSyncRoot) GetFilesToCleanup(environment Environment) []string {
 	transferResource := m.GetTransferResource(environment)
 	return []string{
 		transferResource.Name,
 	}
 }
 
-func (m FilesSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
+func (m *FilesSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
 	config := m.Config
 	if environment.EnvironmentName == LOCAL_ENVIRONMENT_NAME {
 		config = m.getEffectiveLocalDetails()
@@ -122,7 +122,11 @@ func (m FilesSyncRoot) GetTransferResource(environment Environment) SyncerTransf
 	}
 }
 
-func (syncConfig FilesSyncRoot) getEffectiveLocalDetails() BaseFilesSync {
+func (m *FilesSyncRoot) SetTransferResource(transferResourceName string) error {
+	return fmt.Errorf("Setting the transfer resource is not supported for files")
+}
+
+func (syncConfig *FilesSyncRoot) getEffectiveLocalDetails() BaseFilesSync {
 	returnDetails := BaseFilesSync{
 		SyncPath: syncConfig.Config.SyncPath,
 	}

--- a/synchers/mariadb.go
+++ b/synchers/mariadb.go
@@ -29,9 +29,10 @@ type MariadbSyncLocal struct {
 }
 
 type MariadbSyncRoot struct {
-	Config         BaseMariaDbSync
-	LocalOverrides MariadbSyncLocal `yaml:"local"`
-	TransferId     string
+	Config                   BaseMariaDbSync
+	LocalOverrides           MariadbSyncLocal `yaml:"local"`
+	TransferId               string
+	TransferResourceOverride string
 }
 
 // Init related types and functions follow
@@ -78,7 +79,7 @@ func init() {
 	RegisterSyncer(MariadbSyncPlugin{})
 }
 
-func (m MariadbSyncRoot) IsInitialized() (bool, error) {
+func (m *MariadbSyncRoot) IsInitialized() (bool, error) {
 
 	var missingEnvvars []string
 
@@ -105,12 +106,12 @@ func (m MariadbSyncRoot) IsInitialized() (bool, error) {
 	return true, nil
 }
 
-func (root MariadbSyncRoot) PrepareSyncer() (Syncer, error) {
+func (root *MariadbSyncRoot) PrepareSyncer() (Syncer, error) {
 	root.TransferId = strconv.FormatInt(time.Now().UnixNano(), 10)
 	return root, nil
 }
 
-func (root MariadbSyncRoot) GetPrerequisiteCommand(environment Environment, command string) SyncCommand {
+func (root *MariadbSyncRoot) GetPrerequisiteCommand(environment Environment, command string) SyncCommand {
 	lagoonSyncBin, _ := utils.FindLagoonSyncOnEnv()
 
 	return SyncCommand{
@@ -122,7 +123,7 @@ func (root MariadbSyncRoot) GetPrerequisiteCommand(environment Environment, comm
 	}
 }
 
-func (root MariadbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) []SyncCommand {
+func (root *MariadbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) []SyncCommand {
 	m := root.Config
 
 	if sourceEnvironment.EnvironmentName == LOCAL_ENVIRONMENT_NAME {
@@ -166,7 +167,7 @@ func (root MariadbSyncRoot) GetRemoteCommand(sourceEnvironment Environment) []Sy
 	}
 }
 
-func (m MariadbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCommand {
+func (m *MariadbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCommand {
 	l := m.Config
 	if targetEnvironment.EnvironmentName == LOCAL_ENVIRONMENT_NAME {
 		l = m.getEffectiveLocalDetails()
@@ -195,7 +196,7 @@ func (m MariadbSyncRoot) GetLocalCommand(targetEnvironment Environment) []SyncCo
 	}
 }
 
-func (m MariadbSyncRoot) GetFilesToCleanup(environment Environment) []string {
+func (m *MariadbSyncRoot) GetFilesToCleanup(environment Environment) []string {
 	transferResource := m.GetTransferResource(environment)
 	resourceNameWithoutGz := strings.TrimSuffix(transferResource.Name, filepath.Ext(transferResource.Name))
 	return []string{
@@ -204,13 +205,22 @@ func (m MariadbSyncRoot) GetFilesToCleanup(environment Environment) []string {
 	}
 }
 
-func (m MariadbSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
+func (m *MariadbSyncRoot) GetTransferResource(environment Environment) SyncerTransferResource {
+	resourceName := fmt.Sprintf("%vlagoon_sync_mariadb_%v.sql.gz", m.GetOutputDirectory(), m.TransferId)
+	if m.TransferResourceOverride != "" {
+		resourceName = m.TransferResourceOverride
+	}
 	return SyncerTransferResource{
-		Name:        fmt.Sprintf("%vlagoon_sync_mariadb_%v.sql.gz", m.GetOutputDirectory(), m.TransferId),
+		Name:        resourceName,
 		IsDirectory: false}
 }
 
-func (root MariadbSyncRoot) GetOutputDirectory() string {
+func (m *MariadbSyncRoot) SetTransferResource(transferResourceName string) error {
+	m.TransferResourceOverride = transferResourceName
+	return nil
+}
+
+func (root *MariadbSyncRoot) GetOutputDirectory() string {
 	m := root.Config
 	if len(m.OutputDirectory) == 0 {
 		return "/tmp/"
@@ -218,7 +228,7 @@ func (root MariadbSyncRoot) GetOutputDirectory() string {
 	return m.OutputDirectory
 }
 
-func (syncConfig MariadbSyncRoot) getEffectiveLocalDetails() BaseMariaDbSync {
+func (syncConfig *MariadbSyncRoot) getEffectiveLocalDetails() BaseMariaDbSync {
 	returnDetails := BaseMariaDbSync{
 		DbHostname:      syncConfig.Config.DbHostname,
 		DbUsername:      syncConfig.Config.DbUsername,

--- a/synchers/syncdefs.go
+++ b/synchers/syncdefs.go
@@ -20,6 +20,8 @@ type Syncer interface {
 	GetLocalCommand(environment Environment) []SyncCommand
 	// GetTransferResource will return the command that executes the transfer
 	GetTransferResource(environment Environment) SyncerTransferResource
+	// SetTransferResource allows for the overriding of the resource transfer name that's typically generated
+	SetTransferResource(transferResourceName string) error
 	// GetFilesToCleanup will return a list of files to be deleted after completing the transfer
 	GetFilesToCleanup(environment Environment) []string
 	// PrepareSyncer does any preparations required on a Syncer before it is used

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -28,15 +28,16 @@ func UnmarshallLagoonYamlToLagoonSyncStructure(data []byte) (SyncherConfigRoot, 
 }
 
 type RunSyncProcessFunctionTypeArguments struct {
-	SourceEnvironment Environment
-	TargetEnvironment Environment
-	LagoonSyncer      Syncer
-	SyncerType        string
-	DryRun            bool
-	SshOptions        SSHOptions
-	SkipSourceCleanup bool
-	SkipTargetCleanup bool
-	SkipTargetImport  bool
+	SourceEnvironment    Environment
+	TargetEnvironment    Environment
+	LagoonSyncer         Syncer
+	SyncerType           string
+	DryRun               bool
+	SshOptions           SSHOptions
+	SkipSourceCleanup    bool
+	SkipTargetCleanup    bool
+	SkipTargetImport     bool
+	TransferResourceName string
 }
 
 type RunSyncProcessFunctionType = func(args RunSyncProcessFunctionTypeArguments) error


### PR DESCRIPTION
This is a first step to address #93 - next steps will be to add explicit "backup" and "restore" commands to lagoon sync

It adds a new command like argument `transfer-resource-name` that allows one to specify the name of the resource that's transferred, this can effectively be used to create a named backup, as below:

lagoon-sync sync mariadb -p <projectname> -e <environmentname> --skip-target-import --skip-target-cleanup --transfer-resource-name="/tmp/test.sql.gz"