### PR TITLE
Additional to-file and from-file sub commands

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -31,6 +31,7 @@ var dryRun bool
 var verboseSSH bool
 var RsyncArguments string
 var runSyncProcess synchers.RunSyncProcessFunctionType
+var skipSourceRun bool
 var skipSourceCleanup bool
 var skipTargetCleanup bool
 var skipTargetImport bool
@@ -46,8 +47,19 @@ var syncCmd = &cobra.Command{
 }
 
 func syncCommandRun(cmd *cobra.Command, args []string) {
-	SyncerType := args[0]
-	viper.Set("syncer-type", args[0])
+	SyncerType := ""
+	if len(args) > 0 {
+		SyncerType = args[0]
+		viper.Set("syncer-type", args[0])
+	} else {
+		if cmd.Name() == "to-file" || cmd.Name() == "from-file" {
+			// set default as mariadb for now if no arg is given
+			SyncerType = "mariadb"
+		} else {
+			fmt.Println("Error: No SyncerType provided.")
+			return
+		}
+	}
 
 	var configRoot synchers.SyncherConfigRoot
 
@@ -175,6 +187,7 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 		SyncerType:           SyncerType,
 		DryRun:               dryRun,
 		SshOptions:           sshOptions,
+		SkipSourceRun:        skipSourceRun,
 		SkipTargetCleanup:    skipTargetCleanup,
 		SkipSourceCleanup:    skipSourceCleanup,
 		SkipTargetImport:     skipTargetImport,
@@ -209,6 +222,47 @@ func confirmPrompt(message string) (bool, error) {
 	return false, err
 }
 
+func addToFileSubCommand(parentCmd *cobra.Command) {
+	var toFileCmd = &cobra.Command{
+		Use:   "to-file",
+		Short: "Sync to a file",
+		Long:  "Sync/Dump to a file to produce a resource dump",
+		Run: func(cmd *cobra.Command, args []string) {
+			fileFlag, _ := cmd.Parent().PersistentFlags().GetString("transfer-resource-name")
+			fmt.Println("You are about to dump to:", fileFlag)
+
+			// set the skipTargetImport and skipTargetCleanup flags to true
+			cmd.Parent().PersistentFlags().Set("skip-target-import", "true")
+			cmd.Parent().PersistentFlags().Set("skip-source-cleanup", "true")
+			cmd.Parent().PersistentFlags().Set("skip-target-cleanup", "true")
+
+			syncCommandRun(cmd, args)
+		},
+	}
+
+	parentCmd.AddCommand(toFileCmd)
+}
+
+func addFromFileSubCommand(parentCmd *cobra.Command) {
+	var fromFileCmd = &cobra.Command{
+		Use:   "from-file",
+		Short: "Sync from a file",
+		Long:  "Sync from a file and perform related actions",
+		Run: func(cmd *cobra.Command, args []string) {
+			fileFlag, _ := cmd.Parent().PersistentFlags().GetString("transfer-resource-name")
+			fmt.Println("You are about to import from:", fileFlag)
+
+			cmd.Parent().PersistentFlags().Set("skip-source-run", "true")
+			cmd.Parent().PersistentFlags().Set("skip-source-cleanup", "true")
+			cmd.Parent().PersistentFlags().Set("skip-target-cleanup", "true")
+
+			syncCommandRun(cmd, args)
+		},
+	}
+
+	parentCmd.AddCommand(fromFileCmd)
+}
+
 func init() {
 	rootCmd.AddCommand(syncCmd)
 	syncCmd.PersistentFlags().StringVarP(&ProjectName, "project-name", "p", "", "The Lagoon project name of the remote system")
@@ -224,10 +278,14 @@ func init() {
 	syncCmd.PersistentFlags().BoolVar(&noCliInteraction, "no-interaction", false, "Disallow interaction")
 	syncCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Don't run the commands, just preview what will be run")
 	syncCmd.PersistentFlags().StringVarP(&RsyncArguments, "rsync-args", "r", "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX --recursive --compress", "Pass through arguments to change the behaviour of rsync")
+	syncCmd.PersistentFlags().BoolVar(&skipSourceRun, "skip-source-run", false, "Don't run any ops on the source")
 	syncCmd.PersistentFlags().BoolVar(&skipSourceCleanup, "skip-source-cleanup", false, "Don't clean up any of the files generated on the source")
 	syncCmd.PersistentFlags().BoolVar(&skipTargetCleanup, "skip-target-cleanup", false, "Don't clean up any of the files generated on the target")
 	syncCmd.PersistentFlags().BoolVar(&skipTargetImport, "skip-target-import", false, "This will skip the import step on the target, in combination with 'no-target-cleanup' this essentially produces a resource dump")
-	syncCmd.PersistentFlags().StringVarP(&namedTransferResource, "transfer-resource-name", "", "", "The name of the temporary file to be used to transfer generated resources (db dumps, etc) - random /tmp file otherwise")
+	syncCmd.PersistentFlags().StringVarP(&namedTransferResource, "transfer-resource-name", "f", "", "The name of the temporary file to be used to transfer generated resources (db dumps, etc) - random /tmp file otherwise")
+
+	addToFileSubCommand(syncCmd)
+	addFromFileSubCommand(syncCmd)
 
 	// By default, we hook up the syncers.RunSyncProcess function to the runSyncProcess variable
 	// by doing this, it lets us easily override it for testing the command - but for most of the time

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -34,6 +34,7 @@ type RunSyncProcessFunctionTypeArguments struct {
 	SyncerType           string
 	DryRun               bool
 	SshOptions           SSHOptions
+	SkipSourceRun        bool
 	SkipSourceCleanup    bool
 	SkipTargetCleanup    bool
 	SkipTargetImport     bool
@@ -57,10 +58,12 @@ func RunSyncProcess(args RunSyncProcessFunctionTypeArguments) error {
 		return err
 	}
 
-	err = SyncRunSourceCommand(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
-	if err != nil {
-		_ = SyncCleanUp(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
-		return err
+	if !args.SkipSourceRun {
+		err = SyncRunSourceCommand(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
+		if err != nil {
+			_ = SyncCleanUp(args.SourceEnvironment, args.LagoonSyncer, args.DryRun, args.SshOptions)
+			return err
+		}
 	}
 
 	args.TargetEnvironment, err = RunPrerequisiteCommand(args.TargetEnvironment, args.LagoonSyncer, args.SyncerType, args.DryRun, args.SshOptions)


### PR DESCRIPTION
As per #80 - this adds two new sub-commands under sync: `to-file` and `from-file`. This enables a user to directly import resources from a dump file into a given target environment and it also allows a user to run only a resource dump to file.

```
$ lagoon-sync sync test to-file --help

Use Lagoon-Sync to sync an external environments resources with the local environment

Usage:
  lagoon-sync sync [mariadb|files|mongodb|postgres|etc.] [flags]
  lagoon-sync sync [command]

Available Commands:
  from-file   Sync from a file
  to-file     Sync to a file

Flags:
      --dry-run                          Don't run the commands, just preview what will be run
  -h, --help                             help for sync
      --no-interaction                   Disallow interaction
  -p, --project-name string              The Lagoon project name of the remote system
  -r, --rsync-args string                Pass through arguments to change the behaviour of rsync (default "--omit-dir-times --no-perms --no-group --no-owner --chmod=ugo=rwX --recursive --compress")
  -s, --service-name string              The service name (default is 'cli'
      --skip-source-cleanup              Don't clean up any of the files generated on the source
      --skip-source-run                  Don't run any ops on the source
      --skip-target-cleanup              Don't clean up any of the files generated on the target
      --skip-target-import               This will skip the import step on the target, in combination with 'no-target-cleanup' this essentially produces a resource dump
  -e, --source-environment-name string   The Lagoon environment name of the source system
  -H, --ssh-host string                  Specify your lagoon ssh host, defaults to 'ssh.lagoon.amazeeio.cloud' (default "ssh.lagoon.amazeeio.cloud")
  -i, --ssh-key string                   Specify path to a specific SSH key to use for authentication
  -P, --ssh-port string                  Specify your ssh port, defaults to '32222' (default "32222")
  -t, --target-environment-name string   The target environment name (defaults to local)
  -f, --transfer-resource-name string    The name of the temporary file to be used to transfer generated resources (db dumps, etc) - random /tmp file otherwise
      --verbose                          Run ssh commands in verbose (useful for debugging)

Global Flags:
      --config string   Path to the file used to set lagoon-sync configuration
      --show-debug      Shows debug information

Use "lagoon-sync sync [command] --help" for more information about a command.
```

The default syncher is `mariadb` so you can omit it as as argument after `sync`.

Examples:

This `to-file` example will perform a database dump of the dev environment.
```
lagoon-sync sync mariadb to-file -f dev-db-dump.sql.gz -p example-project -e dev --dry-run
```

This `from-file` example will import a local database dump into the dev environment of the project.
```
lagoon-sync sync mariadb from-file -f local-db-dump.sql.gz -p example-project -t dev --dry-run
```
