### PR TITLE
Fix postgres errors on restoration of object ownership

### DIFF
--- a/synchers/postgres.go
+++ b/synchers/postgres.go
@@ -141,7 +141,7 @@ func (m *PostgresSyncRoot) GetLocalCommand(environment Environment) []SyncComman
 	l := m.getEffectiveLocalDetails()
 	transferResource := m.GetTransferResource(environment)
 	return []SyncCommand{{
-		command: fmt.Sprintf("PGPASSWORD=\"%s\" pg_restore -c -x -w -h%s -d%s -p%s -U%s %s", l.DbPassword, l.DbHostname, l.DbDatabase, l.DbPort, l.DbUsername, transferResource.Name),
+		command: fmt.Sprintf("PGPASSWORD=\"%s\" pg_restore -O -c -x -w -h%s -d%s -p%s -U%s %s", l.DbPassword, l.DbHostname, l.DbDatabase, l.DbPort, l.DbUsername, transferResource.Name),
 	},
 	}
 }


### PR DESCRIPTION
Object ownership will default to the user pg_restore used to connect, which will be the same that is used in all other cases.

closes #100 