### PR TITLE
Better error logging for SSH commands

### DIFF
--- a/synchers/syncdefs.go
+++ b/synchers/syncdefs.go
@@ -101,6 +101,6 @@ func GenerateRemoteCommand(remoteEnvironment Environment, command string, sshOpt
 		serviceArgument = fmt.Sprintf("service=%v", remoteEnvironment.ServiceName)
 	}
 
-	return fmt.Sprintf("ssh%s -tt -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\" -p %s %s@%s %s '%s'",
+	return fmt.Sprintf("ssh%s -tt -o LogLevel=FATAL -o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\" -p %s %s@%s %s '%s'",
 		sshOptionsStr.String(), sshOptions.Port, remoteEnvironment.GetOpenshiftProjectName(), sshOptions.Host, serviceArgument, command)
 }

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -269,9 +269,14 @@ func SyncRunTargetCommand(targetEnvironment Environment, syncer Syncer, dryRun b
 
 		utils.LogExecutionStep(fmt.Sprintf("Running the following for target (%s)", targetEnvironment.EnvironmentName), execString)
 		if !dryRun {
-			err, _, errstring := utils.Shellout(execString)
+			err, outstring, errstring := utils.Shellout(execString)
 			if err != nil {
-				utils.LogFatalError(errstring, nil)
+				utils.LogError(outstring, nil)
+				if errstring != "" {
+					utils.LogFatalError(errstring, nil)
+				} else {
+					utils.LogFatalError(fmt.Sprintf("Error: %s", err), nil)
+				}
 				return err
 			}
 		}

--- a/utils/logs.go
+++ b/utils/logs.go
@@ -65,6 +65,20 @@ func LogDebugInfo(message string, output interface{}) {
 	}
 }
 
+func LogError(message string, output interface{}) {
+	logger := log.New(os.Stdout)
+	if colour {
+		logger.WithColor()
+	} else {
+		logger.WithoutColor()
+	}
+	if output == nil {
+		logger.Error(message)
+	} else if output != nil {
+		logger.Error(message, output)
+	}
+}
+
 func LogFatalError(message string, output interface{}) {
 	logger := log.New(os.Stdout)
 	if colour {


### PR DESCRIPTION
This PR does two things:

1. Supress SSH warnings
2. Log SSH stdout on error

When trying to sync a database with the wrong password

before:
```bash
[INFO]  2023/09/28 14:42:55 Running the following for target (pr-3) ssh -tt -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -p 32222 amazeeio-example-pr-3@ssh.lagoon.amazeeio.cloud service=cli 'mysql -h${MARIADB_HOST:-mariadb} -u${MARIADB_USERNAME:-drupal} -pfoo -P${MARIADB_PORT:-3306} ${MARIADB_DATABASE:-drupal} < /tmp/lagoon_sync_mariadb_1695912112725148153.sql'
[FATAL] 2023/09/28 14:43:05 github.com/uselagoon/lagoon-sync/utils.LogFatalError:logs.go:76 Warning: Permanently added '[ssh.lagoon.amazeeio.cloud]:32222' (ED25519) to the list of known hosts.
Connection to ssh.lagoon.amazeeio.cloud closed.
```

after:
```bash
INFO]  2023/09/28 18:44:06 Running the following for target (pr-3) ssh -tt -o LogLevel=FATAL -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -p 32222 amazeeio-example-pr-3@ssh.lagoon.amazeeio.cloud service=cli 'mysql -h${MARIADB_HOST:-mariadb} -u${MARIADB_USERNAME:-drupal} -pfoo -P${MARIADB_PORT:-3306} ${MARIADB_DATABASE:-drupal} < /tmp/lagoon_sync_mariadb_1695926615304245222.sql'
[ERROR] 2023/09/28 18:44:15 github.com/uselagoon/lagoon-sync/utils.LogError:logs.go:76 ERROR 1045 (28000): Access denied for user 'redacted'@'redacted' (using password: YES)
command terminated with exit code 1

[FATAL] 2023/09/28 18:44:15 github.com/uselagoon/lagoon-sync/utils.LogFatalError:logs.go:90 Error: exit status 1
```

closes #103 