### PR TITLE
Fix .lagoon.yml not being checked for configs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,7 +122,7 @@ func processConfig(cfgFile string) error {
 	// Next, check for common lagoon config files and override defaults.
 	for _, path := range paths {
 		cfgFiles := []string{
-			// filepath.Join(path, ".lagoon.yml"),
+			filepath.Join(path, ".lagoon.yml"),
 			filepath.Join(path, ".lagoon-sync.yml"),
 			filepath.Join(path, ".lagoon-sync"),
 		}


### PR DESCRIPTION
If a project only has `lagoon-sync` config stored in `.lagoon.yml`, it won't be loaded unless it's explicitly passed with `--config` argument.

This fixes it so that `.lagoon.yml` is automatically checked.