### PR TITLE
Adds default fallback ssh key and skip agent options

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -151,21 +151,6 @@ func syncCommandRun(cmd *cobra.Command, args []string) {
 		sshKey = sshConfig.PrivateKey
 	}
 
-	if sshKey == "" { //let's try guess it from the OS
-		userPath, err := os.UserHomeDir()
-		if err != nil {
-			utils.LogWarning("No ssh key given and no home directory available", os.Stdout)
-		}
-		potentialKey := fmt.Sprintf("%s/.ssh/id_rsa", userPath)
-		_, err = os.Stat(potentialKey)
-		if err != nil {
-			if SSHSkipAgent == true {
-				utils.LogFatalError(fmt.Sprintf("Unable to find key at fallback location '%v' - please provide an ssh key with the `--ssh-key` option, or use the ssh-agent", potentialKey), os.Stderr)
-			}
-		}
-		sshKey = potentialKey
-	}
-
 	sshVerbose := SSHVerbose
 	if sshConfig.Verbose && !sshVerbose {
 		sshVerbose = sshConfig.Verbose

--- a/synchers/syncdefs.go
+++ b/synchers/syncdefs.go
@@ -69,6 +69,7 @@ type SSHOptions struct {
 	Port       string `yaml:"port,omitempty" json:"port,omitempty"`
 	Verbose    bool   `yaml:"verbose,omitempty" json:"verbose,omitempty"`
 	PrivateKey string `yaml:"privateKey,omitempty" json:"privateKey,omitempty"`
+	SkipAgent  bool
 	RsyncArgs  string `yaml:"rsyncArgs,omitempty" json:"rsyncArgs,omitempty"`
 }
 

--- a/synchers/syncutils.go
+++ b/synchers/syncutils.go
@@ -51,7 +51,8 @@ func RunSyncProcess(args RunSyncProcessFunctionTypeArguments) error {
 
 	//TODO: this can come out.
 	args.SourceEnvironment, err = RunPrerequisiteCommand(args.SourceEnvironment, args.LagoonSyncer, args.SyncerType, args.DryRun, args.SshOptions)
-	sourceRsyncPath := args.SourceEnvironment.RsyncPath
+	sourceRsyncPath := "rsync" //args.SourceEnvironment.RsyncPath
+	args.SourceEnvironment.RsyncPath = "rsync"
 	if err != nil {
 		_ = PrerequisiteCleanUp(args.SourceEnvironment, sourceRsyncPath, args.DryRun, args.SshOptions)
 		return err
@@ -137,7 +138,7 @@ func SyncRunSourceCommand(remoteEnvironment Environment, syncer Syncer, dryRun b
 					log.Println(response)
 				}
 			} else {
-				err, output := utils.RemoteShellout(execString, remoteEnvironment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey)
+				err, output := utils.RemoteShellout(execString, remoteEnvironment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey, sshOptions.SkipAgent)
 				utils.LogDebugInfo(output, nil)
 				if err != nil {
 					utils.LogFatalError("Unable to exec remote command: "+err.Error(), nil)
@@ -237,7 +238,7 @@ func SyncRunTransfer(sourceEnvironment Environment, targetEnvironment Environmen
 	if !dryRun {
 
 		if executeRsyncRemotelyOnTarget {
-			err, output := utils.RemoteShellout(execString, targetEnvironment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey)
+			err, output := utils.RemoteShellout(execString, targetEnvironment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey, sshOptions.SkipAgent)
 			utils.LogDebugInfo(output, nil)
 			if err != nil {
 				utils.LogFatalError("Unable to exec remote command: "+err.Error(), nil)
@@ -282,7 +283,7 @@ func SyncRunTargetCommand(targetEnvironment Environment, syncer Syncer, dryRun b
 					return err
 				}
 			} else {
-				err, output := utils.RemoteShellout(execString, targetEnvironment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey)
+				err, output := utils.RemoteShellout(execString, targetEnvironment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey, sshOptions.SkipAgent)
 				utils.LogDebugInfo(output, nil)
 				if err != nil {
 					utils.LogFatalError("Unable to exec remote command: "+err.Error(), nil)
@@ -312,7 +313,7 @@ func SyncCleanUp(environment Environment, syncer Syncer, dryRun bool, sshOptions
 		utils.LogExecutionStep("Running the following", execString)
 		if !dryRun {
 			if environment.EnvironmentName != LOCAL_ENVIRONMENT_NAME {
-				err, output := utils.RemoteShellout(execString, environment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey)
+				err, output := utils.RemoteShellout(execString, environment.GetOpenshiftProjectName(), sshOptions.Host, sshOptions.Port, sshOptions.PrivateKey, sshOptions.SkipAgent)
 				utils.LogDebugInfo(output, nil)
 				if err != nil {
 					utils.LogFatalError("Unable to exec remote command: "+err.Error(), nil)

--- a/utils/shell.go
+++ b/utils/shell.go
@@ -2,14 +2,19 @@ package utils
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 const ShellToUse = "sh"
+
+var validAuthMethod *ssh.AuthMethod
 
 func Shellout(command string) (error, string, string) {
 	var stdout bytes.Buffer
@@ -21,6 +26,52 @@ func Shellout(command string) (error, string, string) {
 	return err, stdout.String(), stderr.String()
 }
 
+func getAuthMethodFromPrivateKey(filename string) (ssh.AuthMethod, error) {
+	privateKeyBytes, err := os.ReadFile(filename)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(privateKeyBytes) > 0 {
+		// Parse the private key
+		signer, err := ssh.ParsePrivateKey(privateKeyBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		// SSH client configuration
+		authKeys := ssh.PublicKeys(signer)
+		return authKeys, nil
+
+	}
+	return nil, errors.New(fmt.Sprint("No data in privateKey: ", filename))
+}
+
+func findSSHKeyFiles(directory string) ([]string, error) {
+	var keys []string
+	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && filepath.Ext(path) == ".pub" {
+			privateKeyPath := path[:len(path)-4] // remove ".pub" extension
+			keys = append(keys, privateKeyPath)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func isPassphraseMissingError(err error) bool {
+	_, ok := err.(*ssh.PassphraseMissingError)
+	return ok
+}
+
 func RemoteShellout(command string, remoteUser string, remoteHost string, remotePort string, privateKeyfile string, skipSshAgent bool) (error, string) {
 
 	sshAuthSock, present := os.LookupEnv("SSH_AUTH_SOCK")
@@ -28,37 +79,12 @@ func RemoteShellout(command string, remoteUser string, remoteHost string, remote
 
 	var authMethods []ssh.AuthMethod
 
-	if skipAgent != true {
-		// Connect to SSH agent to ask for unencrypted private keys
-		if sshAgentConn, err := net.Dial("unix", sshAuthSock); err == nil {
-			sshAgent := agent.NewClient(sshAgentConn)
-			keys, _ := sshAgent.List()
-			if len(keys) > 0 {
-				agentAuthmethods := ssh.PublicKeysCallback(sshAgent.Signers)
-				authMethods = append(authMethods, agentAuthmethods)
-			}
-		}
-	} else {
-		LogDebugInfo("Skipping ssh agent", os.Stdout)
+	if validAuthMethod == nil { // This makes it so that in subsequent calls, we don't have to recheck all auth methods
+		authMethods = getAuthmethods(skipAgent, privateKeyfile, sshAuthSock, authMethods)
 	}
 
-	privateKeyBytes, err := os.ReadFile(privateKeyfile)
-
-	// if there are authMethods already, let's keep going
-	if err != nil && len(authMethods) == 0 {
-		return err, ""
-	}
-
-	if len(privateKeyBytes) > 0 {
-		// Parse the private key
-		signer, err := ssh.ParsePrivateKey(privateKeyBytes)
-		if err != nil {
-			return err, ""
-		}
-
-		// SSH client configuration
-		authKeys := ssh.PublicKeys(signer)
-		authMethods = append(authMethods, authKeys)
+	if len(authMethods) == 0 && validAuthMethod == nil {
+		return errors.New("No valid authentication methods provided"), ""
 	}
 
 	config := &ssh.ClientConfig{
@@ -67,13 +93,38 @@ func RemoteShellout(command string, remoteUser string, remoteHost string, remote
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	// Connect to the remote server
-	client, err := ssh.Dial("tcp", remoteHost+":"+remotePort, config)
-	if err != nil {
-		return err, ""
+	var client *ssh.Client
+	var err error
+	if validAuthMethod != nil {
+		LogDebugInfo("Have a valid auth method", os.Stdout)
+		// Connect to the remote server
+		config.Auth = []ssh.AuthMethod{
+			*validAuthMethod,
+		}
+		client, err = ssh.Dial("tcp", remoteHost+":"+remotePort, config)
+		if err != nil {
+			return err, ""
+		}
+		defer client.Close()
+	} else {
+		//we need to iterate over the auth methods till we find one that works
+		LogDebugInfo("Trying an auth method", os.Stdout)
+		for _, am := range authMethods {
+			config.Auth = []ssh.AuthMethod{
+				am,
+			}
+			client, err = ssh.Dial("tcp", remoteHost+":"+remotePort, config)
+			if err != nil {
+				continue
+			}
+			validAuthMethod = &am // set the valid auth method so that future calls won't need to retry
+			break
+		}
+		if validAuthMethod == nil {
+			return errors.New("unable to find valid auth method for ssh"), ""
+		}
+		defer client.Close()
 	}
-
-	defer client.Close()
 
 	// Create a session
 	session, err := client.NewSession()
@@ -104,4 +155,63 @@ func RemoteShellout(command string, remoteUser string, remoteHost string, remote
 	}
 
 	return nil, outputBuffer.String()
+}
+
+func getAuthmethods(skipAgent bool, privateKeyfile string, sshAuthSock string, authMethods []ssh.AuthMethod) []ssh.AuthMethod {
+	if skipAgent != true && privateKeyfile == "" {
+		// Connect to SSH agent to ask for unencrypted private keys
+		if sshAgentConn, err := net.Dial("unix", sshAuthSock); err == nil {
+			sshAgent := agent.NewClient(sshAgentConn)
+			keys, _ := sshAgent.List()
+			if len(keys) > 0 {
+				agentAuthmethods := ssh.PublicKeysCallback(sshAgent.Signers)
+				authMethods = append(authMethods, agentAuthmethods)
+			}
+		}
+	} else {
+		LogDebugInfo("Skipping ssh agent", os.Stdout)
+	}
+
+	if privateKeyfile == "" { //let's try guess it from the OS
+		userPath, err := os.UserHomeDir()
+		if err != nil {
+			LogWarning("No ssh key given and no home directory available", os.Stdout)
+		}
+
+		userPath = filepath.Join(userPath, ".ssh")
+
+		if _, err := os.Stat(userPath); err == nil {
+			files, err := findSSHKeyFiles(userPath)
+			if err != nil {
+				LogWarning(err.Error(), os.Stdout)
+			}
+			for _, f := range files {
+				am, err := getAuthMethodFromPrivateKey(f)
+				if err != nil {
+					switch {
+					case isPassphraseMissingError(err):
+						LogDebugInfo(fmt.Sprintf("Found a passphrase based ssh key: %v", err.Error()), os.Stdout)
+					default:
+						LogWarning(err.Error(), os.Stdout)
+					}
+				} else {
+					authMethods = append(authMethods, am)
+				}
+			}
+		} else {
+			LogWarning("Unable to find .ssh directory in user home", os.Stdout)
+		}
+	} else {
+		privateKeyFiles := []string{
+			privateKeyfile,
+		}
+
+		for _, kf := range privateKeyFiles {
+			am, err := getAuthMethodFromPrivateKey(kf)
+			if err == nil {
+				authMethods = append(authMethods, am)
+			}
+		}
+	}
+	return authMethods
 }

--- a/utils/shell_test.go
+++ b/utils/shell_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_findSSHKeyFiles(t *testing.T) {
+	type args struct {
+		directory string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "Run on test directory",
+			args: args{directory: "../test-resources/shell-tests/test_findSSHKeyFiles"},
+			want: []string{
+				"../test-resources/shell-tests/test_findSSHKeyFiles/key1",
+				"../test-resources/shell-tests/test_findSSHKeyFiles/key2",
+				"../test-resources/shell-tests/test_findSSHKeyFiles/key3",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findSSHKeyFiles(tt.args.directory)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findSSHKeyFiles() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findSSHKeyFiles() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/shell_test.go
+++ b/utils/shell_test.go
@@ -1,40 +1,88 @@
 package utils
 
 import (
-	"reflect"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
-func Test_findSSHKeyFiles(t *testing.T) {
-	type args struct {
-		directory string
+/**
+* generatePrivateKey is used to generate a random private key - we're using this in our tests
+ */
+func generatePrivateKey(outputDir string) (string, error) {
+	// Generate a new private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", err
 	}
+
+	// Encode private key to PEM format
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privateKeyBytes})
+
+	// Generate a random filename
+	randomFilename := fmt.Sprintf("private_key_%d.pem", time.Now().UnixNano())
+
+	// Save private key to a file in the specified directory with the random filename
+	privateKeyPath := filepath.Join(outputDir, randomFilename)
+	err = os.WriteFile(privateKeyPath, privateKeyPEM, 0600)
+	if err != nil {
+		return "", err
+	}
+
+	return privateKeyPath, nil
+}
+
+const test_findSSHKeyFilesNumber = 3
+
+func Test_findSSHKeyFiles(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    args
-		want    []string
+		want    int
 		wantErr bool
 	}{
 		{
-			name: "Run on test directory",
-			args: args{directory: "../test-resources/shell-tests/test_findSSHKeyFiles"},
-			want: []string{
-				"../test-resources/shell-tests/test_findSSHKeyFiles/key1",
-				"../test-resources/shell-tests/test_findSSHKeyFiles/key2",
-				"../test-resources/shell-tests/test_findSSHKeyFiles/key3",
-			},
+			name:    "Run on test directory",
+			want:    test_findSSHKeyFilesNumber,
 			wantErr: false,
 		},
 	}
+
+	// Let's generate the files
+	tmpDir, err := os.MkdirTemp("", "keypair_test")
+	if err != nil {
+		t.Fatal("Unable to create temporary directory: ", err.Error())
+	}
+
+	defer func() {
+		os.RemoveAll(tmpDir)
+	}()
+
+	privateKeys := []string{}
+
+	for i := 0; i < test_findSSHKeyFilesNumber; i++ {
+		key, err := generatePrivateKey(tmpDir)
+		if err != nil {
+			t.Fatal("Unable to create private key: ", err.Error())
+		}
+		privateKeys = append(privateKeys, key)
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := findSSHKeyFiles(tt.args.directory)
+			got, err := getSSHAuthMethodsFromDirectory(tmpDir)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("findSSHKeyFiles() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getSSHAuthMethodsFromDirectory() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("findSSHKeyFiles() got = %v, want %v", got, tt.want)
+			if len(got) != tt.want {
+				t.Errorf("getSSHAuthMethodsFromDirectory() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This closes #109 - the problem isn't anything other than we weren't looking for default ssh keys, which is dealt with by default with the standard ssh implementation.

This introduces some more robust default ssh key behaviour with fallbacks/defaults, etc.